### PR TITLE
Stable compilation, log reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -344,3 +344,4 @@ lib/Assembly-CSharp.dll
 lib/UnityEngine.dll
 /CompletelyOptional/lib/UnityEngine.dll
 /CompletelyOptional/lib/Assembly-CSharp.dll
+CompletelyOptional/user.targets

--- a/CompletelyOptional/CompletelyOptional.csproj
+++ b/CompletelyOptional/CompletelyOptional.csproj
@@ -153,10 +153,11 @@ copy /Y "$(TargetDir)$(TargetName).xml" "E:\Game\Rain World\mods\$(TargetName).x
 copy /Y "$(TargetPath)" "E:\SteamLibrary\steamapps\common\Rain World\BepInEx\plugins\$(TargetName).dll"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "D:\Drive\Repo\References\RainWorld\$(TargetName).dll"
+    <PostBuildEvent Label="copyoutputTopi">copy /Y "$(TargetPath)" "D:\Drive\Repo\References\RainWorld\$(TargetName).dll"
 copy /Y "$(TargetDir)$(TargetName).xml" "D:\Drive\Repo\References\RainWorld\$(TargetName).xml"
 copy /Y "$(TargetPath)" "E:\Game\Rain World\mods\$(TargetName).dll"
 copy /Y "$(TargetDir)$(TargetName).xml" "E:\Game\Rain World\mods\$(TargetName).xml"
 copy /Y "$(TargetPath)" "E:\SteamLibrary\steamapps\common\Rain World\BepInEx\plugins\$(TargetName).dll"</PostBuildEvent>
   </PropertyGroup>
+  <Import Condition="Exists('user.targets')" Project="user.targets" />
 </Project>

--- a/CompletelyOptional/OptionInterface_DataAPI.cs
+++ b/CompletelyOptional/OptionInterface_DataAPI.cs
@@ -10,7 +10,7 @@ namespace OptionalUI
 {
     public partial class OptionInterface
     {
-        #region customData
+#region customData
 
         /// <summary>
         /// Default <see cref="data"/> of this mod. If this isn't needed, just leave it be.
@@ -110,9 +110,9 @@ namespace OptionalUI
             return false;
         }
 
-        #endregion customData
+#endregion customData
 
-        #region progData
+#region progData
 
         /// <summary>
         /// Default <see cref="progData"/> of this mod. If this isn't needed, just leave it be.
@@ -255,15 +255,17 @@ namespace OptionalUI
             else { return ((SlugcatStats.Name)Math.Max(0, slugcat)).ToString(); }
         }
 
+#if !STABLE
         internal static int GetSlugcatSeed(int slugcat)
         {
         }
+#endif
 
-        #region SlugBase
+#region SlugBase
 
         private static string GetSlugBaseSlugcatName(int slugcat) => SlugBase.PlayerManager.GetCustomPlayer(slugcat).Name;
 
-        #endregion SlugBase
+#endregion SlugBase
 
         // progData1_White.txt
         // progPersData1_White.txt
@@ -320,6 +322,7 @@ namespace OptionalUI
                 //Debug.Log("CM: Got raw data :" + raw[0]);
                 raw = Regex.Split(data, "<slugChar>");
 
+#if !STABLE
                 _progData = new string[Math.Max(_progData.Length, raw.Length)];
                 for (int j = 0; j < raw.Length; j++)
                 {
@@ -330,6 +333,7 @@ namespace OptionalUI
                     }
                     else _progData[j] = raw[j];
                 }
+#endif
                 return;
             }
             catch (Exception ex)
@@ -406,6 +410,6 @@ namespace OptionalUI
             if (slot != OptionScript.Slot || slugcat != OptionScript.Slugcat) { SlotOnChange(); }
         }
 
-        #endregion progData
+#endregion progData
     }
 }

--- a/CompletelyOptional/OptionScript.cs
+++ b/CompletelyOptional/OptionScript.cs
@@ -242,26 +242,27 @@ namespace CompletelyOptional
 
                 try
                 {
-                    object obj = mod.GetType().GetMethod("LoadOI").Invoke(mod, new object[] { });
-                    //Debug.Log(obj);
-                    //itf = (OptionInterface)obj;
-                    //itf = obj as OptionInterface;
-
-                    if (obj.GetType().IsSubclassOf(typeof(OptionInterface)))
+                    var method = mod.GetType().GetMethod("LoadOI");
+                    if (method == null || method.GetParameters().Length > 0 || method.ContainsGenericParameters)
                     {
-                        itf = obj as OptionInterface;
+                        // Mod didn't attempt to interface with CompletelyOptional, don't bother logging it.
+                        itf = new UnconfiguableOI(mod, UnconfiguableOI.Reason.NoInterface);
+                    }
+                    else if (method.Invoke(mod, null) is OptionInterface oi)
+                    {
+                        itf = oi;
                         //Your code
                         Debug.Log($"Loaded OptionInterface from {mod.ModID} (type: {itf.GetType()})");
                     }
                     else
                     {
-                        Debug.Log($"{mod.ModID} does not support CompletelyOptional: LoadOI returns what is not OptionInterface.");
                         itf = new UnconfiguableOI(mod, UnconfiguableOI.Reason.NoInterface);
+                        Debug.Log($"{mod.ModID} did not return an OptionInterface in LoadOI.");
                     }
                 }
                 catch (Exception ex)
                 {
-                    Debug.Log($"{mod.ModID} does not support CompletelyOptional: {ex.Message}");
+                    Debug.Log($"{mod.ModID} threw an exception in LoadOI: {ex.Message}");
                     itf = new UnconfiguableOI(mod, UnconfiguableOI.Reason.NoInterface);
                 }
 
@@ -364,40 +365,50 @@ namespace CompletelyOptional
                 // Load ITF
                 try
                 {
-                    object obj = plugin.GetType().GetMethod("LoadOI").Invoke(plugin, new object[] { });
-
-                    if (obj.GetType().IsSubclassOf(typeof(OptionInterface)))
+                    var method = plugin.GetType().GetMethod("LoadOI");
+                    if (method == null || method.GetParameters().Length > 0 || method.ContainsGenericParameters)
                     {
-                        itf = obj as OptionInterface;
+                        // Mod didn't attempt to interface with CompletelyOptional, don't bother logging it.
+                        itf = new UnconfiguableOI(plugin, UnconfiguableOI.Reason.NoInterface);
+                    }
+                    else if (method.Invoke(plugin, null) is OptionInterface oi)
+                    {
+                        itf = oi;
                         //Your code
                         Debug.Log($"Loaded OptionInterface from {itf.rwMod.ModID} (type: {itf.GetType()})");
                     }
                     else
                     {
                         itf = new UnconfiguableOI(plugin, UnconfiguableOI.Reason.NoInterface);
-                        Debug.Log($"{itf.rwMod.ModID} does not support CompletelyOptional: LoadOI returns what is not OptionInterface.");
+                        Debug.Log($"{itf.rwMod.ModID} did not return an OptionInterface in LoadOI.");
                     }
                 }
                 catch (Exception ex)
                 {
                     itf = new UnconfiguableOI(plugin, UnconfiguableOI.Reason.NoInterface);
-                    if (blackList.Contains<string>(itf.rwMod.ModID)) { continue; }
-                    if (itf.rwMod.ModID.Substring(0, 1) == "_") { continue; }
-                    Debug.Log($"{itf.rwMod.ModID} does not support CompletelyOptional: {ex.Message}");
+
+                    if (blackList.Contains(itf.rwMod.ModID) || itf.rwMod.ModID.Substring(0, 1) == "_") 
+                    { 
+                        continue; 
+                    }
+
+                    Debug.Log($"{itf.rwMod.ModID} threw an exception in LoadOI: {ex.Message}");
                 }
 
                 if (itf is UnconfiguableOI && plugin.Config.Keys.Count > 0)
-                { // Use BepInEx Configuration
+                {
+                    // Use BepInEx Configuration
                     itf = new GeneratedOI(itf.rwMod, plugin.Config);
                 }
 
-                // Initialize ITF
+                // Initialize the interface
                 try
                 {
                     itf.Initialize();
                 }
                 catch (Exception ex)
-                { //try catch better
+                { 
+                    // Try-catch better
                     itf = new UnconfiguableOI(itf.rwMod, new GeneralInitializeException(ex));
                     itf.Initialize();
                 }
@@ -405,8 +416,8 @@ namespace CompletelyOptional
                 {
                     itf = new UnconfiguableOI(itf.rwMod, new NoTabException(itf.rwMod.ModID));
                     itf.Initialize();
-                    //OptionScript.loadedInterfaceDict.Remove(mod.ModID);
-                    //OptionScript.loadedInterfaceDict.Add(mod.ModID, itf);
+                    // OptionScript.loadedInterfaceDict.Remove(mod.ModID);
+                    // OptionScript.loadedInterfaceDict.Add(mod.ModID, itf);
                 }
                 else if (itf.Configuable())
                 {

--- a/CompletelyOptional/OptionScript.cs
+++ b/CompletelyOptional/OptionScript.cs
@@ -350,7 +350,7 @@ namespace CompletelyOptional
                 LoadBaseUnityPlugins();
             }
 
-            Debug.Log($"CompletelyOptional) Finished Initializing {loadedInterfaceDict.Count} OIs");
+            Debug.Log($"CompletelyOptional finished initializing {loadedInterfaceDict.Count} OIs.");
         }
 
         private static void LoadBaseUnityPlugins()
@@ -423,16 +423,16 @@ namespace CompletelyOptional
                 {
                     if (itf.LoadConfig())
                     {
-                        Debug.Log($"CompletelyOptional) {itf.rwMod.ModID} config has been loaded.");
+                        Debug.Log($"{itf.rwMod.ModID} config has been loaded.");
                     }
                     else
                     {
-                        Debug.Log($"CompletelyOptional) {itf.rwMod.ModID} does not have config.txt.");
+                        Debug.Log($"{itf.rwMod.ModID} does not have config.txt.");
                         //itf.Initialize();
                         try
                         {
                             itf.SaveConfig(itf.GrabConfig());
-                            Debug.Log($"CompletelyOptional) {itf.rwMod.ModID} uses default config.");
+                            Debug.Log($"{itf.rwMod.ModID} uses default config.");
                         }
                         catch (Exception e)
                         {


### PR DESCRIPTION
This PR:
- Makes the repository buildable after being pulled with a `STABLE` conditional compilation symbol defined; see `user.targets`.
- Enables contributors to include a `user.targets` file in the same folder as the .csproj to configure the project file to their liking.
- Reduces exceptions thrown when loading OIs.
- Reduces and simplifies logs when loading OIs.

<details>
  <summary>Example `user.targets`</summary>
  
```xml
<?xml version="1.0" encoding="utf-8"?>
<Project>

  <PropertyGroup>
    <SteamPath>your rain world steam path</SteamPath>
    <BepPath>$(SteamPath)\BepInEx</BepPath>

    <DefineConstants>STABLE</DefineConstants>

    <PostBuildEvent Label="copyoutputTopi"></PostBuildEvent>
  </PropertyGroup>

  <ItemGroup>
    <Reference Include="$(BepPath)\core\BepInEx.dll" />
    <Reference Include="$(BepPath)\core\BepInEx.Preloader.dll" />
    <Reference Include="$(BepPath)\core\Mono.Cecil.dll" />
    <Reference Include="$(BepPath)\core\MonoMod.dll" />
    <Reference Include="$(BepPath)\core\MonoMod.Utils.dll" />
    <Reference Include="$(BepPath)\core\MonoMod.RuntimeDetour.dll" />
    <Reference Include="$(BepPath)\plugins\PartialityWrapper\HOOKS-Assembly-CSharp.dll" />
    <Reference Include="$(BepPath)\plugins\PartialityWrapper\Partiality.dll" />
    <Reference Include="$(SteamPath)\RainWorld_Data\Managed\UnityEngine.dll" />
    <Reference Include="Assembly-CSharp">
      <HintPath>your path to a stubbed rain world assembly</HintPath>
    </Reference>
    <Reference Include="SlugBase">
      <HintPath>your path to slugbase</HintPath>
    </Reference>
  </ItemGroup>

</Project>
```
  
</details>

Topicular can still compile the mod as usual.