### PR TITLE
Rework of the Progression Data system tighly coupled to the game save system.

### DIFF
--- a/CompletelyOptional/OptionInterface_DataAPI.cs
+++ b/CompletelyOptional/OptionInterface_DataAPI.cs
@@ -331,11 +331,11 @@ namespace OptionalUI
             else
             {
                 data = Crypto.DecryptString(data, CryptoProgDataKey(slugcat));
-                string[] seedsplit = Regex.Split(data, "<Seed>"); // expected: <Seed>####<Seed>otherjunk
-                if (seedsplit.Length > 1)
+                string[] seedsplit = Regex.Split(data, "<Seed>"); // expected: <Seed>####<Seed>data
+                if (seedsplit.Length >= 3)
                 {
                     if (int.TryParse(seedsplit[1], out int seed) && seed == validSeed)
-                        return data;
+                        return seedsplit[2];
                 }
             }
             return defaultData;
@@ -423,16 +423,16 @@ namespace OptionalUI
         {
             if (loadedFromMemory && seed == saveState.seed && slugcat == saveState.saveStateNumber) return; // We're good ? Not too sure when this happens
 
-            seed = saveState.seed;
-            slugcat = saveState.saveStateNumber;
-
             LoadSave(slugcat);
             LoadPers(slugcat);
             ProgressionChanged(true, false);
         }
 
+
+        
         internal protected virtual void SaveSimulatedDeath(bool saveAsIfPlayerDied, bool saveAsIfPlayerQuit)
         {
+            // Oh snap this runs before the first LoadSave (before GetOrInitiateSaveState returns)
             SavePers(slugcat);
         }
 
@@ -445,18 +445,18 @@ namespace OptionalUI
         /// <summary>
         /// Currently selected saveslot
         /// </summary>
-        public int slot { get; private set; } = -1;
+        public int slot => OptionScript.Slot;
 
         /// <summary>
         /// Currently selected slugcat
         /// </summary>
-        public int slugcat { get; private set; } = -1;
+        public int slugcat =>  OptionScript.Slugcat;
 
         /// <summary>
         /// Seed of currently loaded savestate
         /// Used for validating loaded progression
         /// </summary>
-        public int seed { get; private set; } = -1;
+        public int seed => OptionScript.rw.progression.currentSaveState != null ? OptionScript.rw.progression.currentSaveState.seed : -1;
 
 
         public string GetProgDataOfSlugcat(string name)

--- a/CompletelyOptional/OptionInterface_DataAPI.cs
+++ b/CompletelyOptional/OptionInterface_DataAPI.cs
@@ -377,7 +377,7 @@ namespace OptionalUI
         /// This happens when loading, initializing, wiping etc
         /// Called regardless of there being an actual value change in save/pers/misc data
         /// </summary>
-        internal protected virtual void ProgressionChanged(bool saveAndPers, bool misc) { }
+        internal protected virtual void ProgressionLoaded() { }
 
         internal protected virtual void ProgressionPreSave() { }
 
@@ -386,11 +386,9 @@ namespace OptionalUI
         internal void InitProgression() // Called when the slot file isn't found on the game's side.
         {
             // To match the game having a fresh start, wipe all ?
-            ProgressionPreSave();
             WipeSave(-1);
             WipePers(-1);
             WipeMisc();
-            ProgressionChanged(true, true);
         }
 
         internal void LoadProgression() // Called on load, slot-switch or post-wipe
@@ -398,12 +396,10 @@ namespace OptionalUI
             InitSave();
             InitPers();
             LoadMisc();
-            ProgressionChanged(true, true);
         }
 
         internal void SaveProgression(bool saveState, bool savePers, bool saveMisc)
         {
-            ProgressionPreSave();
             if (saveState) SaveSave(slugcat);
             if (savePers) SavePers(slugcat);
             if (saveMisc) SaveMisc();
@@ -411,21 +407,16 @@ namespace OptionalUI
 
         internal void WipeProgression(int saveStateNumber)
         {
-            ProgressionPreSave();
             WipeSave(saveStateNumber);
             WipePers(saveStateNumber);
             if(saveStateNumber == -1)
                 WipeMisc();
-            ProgressionChanged(true, saveStateNumber == -1);
         }
 
-        internal void LoadSave(SaveState saveState, bool loadedFromMemory, bool loadedFromStarve)
+        internal void LoadSaveState()
         {
-            if (loadedFromMemory && seed == saveState.seed && slugcat == saveState.saveStateNumber) return; // We're good ? Not too sure when this happens
-
             LoadSave(slugcat);
             LoadPers(slugcat);
-            ProgressionChanged(true, false);
         }
 
 

--- a/CompletelyOptional/OptionInterface_DataAPI.cs
+++ b/CompletelyOptional/OptionInterface_DataAPI.cs
@@ -314,13 +314,14 @@ namespace OptionalUI
 
         private string ReadProgressionFile(string file, int slugNumber, int validSeed, string defaultData)
         {
+            // some locals here have the same name as class stuff and caused me a headache at some point
             if (!directory.Exists) return defaultData;
 
             string targetFile = GetTargetFilename(file, slugNumber);
             
             if(!File.Exists(targetFile)) return defaultData;
 
-            data = File.ReadAllText(targetFile, Encoding.UTF8);
+            string data = File.ReadAllText(targetFile, Encoding.UTF8);
             string key = data.Substring(0, 32);
             data = data.Substring(32, data.Length - 32);
             if (Custom.Md5Sum(data) != key)

--- a/CompletelyOptional/OptionMod.cs
+++ b/CompletelyOptional/OptionMod.cs
@@ -78,7 +78,7 @@ namespace CompletelyOptional
 
             OptionsMenuPatch.SubPatch();
             On.ProcessManager.ctor += OptionScript.ProcessManagerCtor;
-            ProgressData.SubPatch();
+            // ProgressData.SubPatch(); moved to post-initialization of OIs, makes no sense to hook before the OIs are even instantiated.
 
             go = new GameObject("OptionController");
             script = go.AddComponent<OptionScript>();

--- a/CompletelyOptional/OptionScript.cs
+++ b/CompletelyOptional/OptionScript.cs
@@ -318,6 +318,10 @@ namespace CompletelyOptional
                 loadedInterfaceDict.Add(itf.rwMod.ModID, itf);
                 //loadedModsDictionary[item.Key].GetType().GetMember("OI")
             }
+            // Progression of loaded OIs
+            ProgressData.SubPatch();
+            if (OptionScript.rw.setup.loadProg) ProgressData.LoadOIsMisc();
+
             #endregion PartialityMods
 
             #region InternalTest

--- a/CompletelyOptional/OptionScript.cs
+++ b/CompletelyOptional/OptionScript.cs
@@ -320,7 +320,7 @@ namespace CompletelyOptional
             }
             // Progression of loaded OIs
             ProgressData.SubPatch();
-            if (OptionScript.rw.setup.loadProg) ProgressData.LoadOIsMisc();
+            if (OptionScript.rw.setup.loadProg) ProgressData.LoadOIsProgression();
 
             #endregion PartialityMods
 

--- a/CompletelyOptional/ProgressData.cs
+++ b/CompletelyOptional/ProgressData.cs
@@ -27,12 +27,12 @@ namespace CompletelyOptional
             {
                 if (oi.hasProgData)
                 {
-                    oi.ProgSaveOrLoad(saveOrLoad);
                     if (!force && saveOrLoad == SaveAndLoad.Save)
                     {
                         oi.saveAsDeath = saveAsDeath;
                         oi.saveAsQuit = saveAsQuit;
                     }
+                    oi.ProgSaveOrLoad(saveOrLoad);
                 }
             }
         }

--- a/CompletelyOptional/ProgressData.cs
+++ b/CompletelyOptional/ProgressData.cs
@@ -53,14 +53,14 @@ namespace CompletelyOptional
         internal static void PlayerProgression_LoadProgression(On.PlayerProgression.orig_LoadProgression orig, PlayerProgression self)
         {
             orig(self);
-            LoadOIsMisc();
+            LoadOIsProgression();
         }
 
         // Called when there's no file to load
         internal static void PlayerProgression_InitiateProgression(On.PlayerProgression.orig_InitiateProgression orig, PlayerProgression self)
         {
             orig(self);
-            InitiateOIsMisc();
+            InitiateOIsProgression();
         }
 
         internal static void PlayerProgression_WipeAll(On.PlayerProgression.orig_WipeAll orig, PlayerProgression self)
@@ -120,30 +120,26 @@ namespace CompletelyOptional
             if (doLog) UnityEngine.Debug.Log(memberName + " : " + text);
         }
 
-        internal static void LoadOIsMisc()
+        internal static void LoadOIsProgression()
         {
             DebugLog();
             foreach (OptionInterface oi in OptionScript.loadedInterfaces)
             {
                 if (oi.hasProgData)
                 {
-                    oi.LoadMisc();
-                    oi.InitSave();
-                    oi.InitPers();
+                    oi.LoadProgression();
                 }
             }
         }
 
-        internal static void InitiateOIsMisc()
+        internal static void InitiateOIsProgression()
         {
             DebugLog();
             foreach (OptionInterface oi in OptionScript.loadedInterfaces)
             {
                 if (oi.hasProgData)
                 {
-                    oi.InitMisc();
-                    oi.InitSave();
-                    oi.InitPers();
+                    oi.InitProgression();
                 }
             }
         }

--- a/CompletelyOptional/ProgressData.cs
+++ b/CompletelyOptional/ProgressData.cs
@@ -34,7 +34,7 @@ namespace CompletelyOptional
             // Reverts and clears
             On.PlayerProgression.WipeAll += PlayerProgression_WipeAll;
             On.PlayerProgression.WipeSaveState += PlayerProgression_WipeSaveState;
-            // On.PlayerProgression.Revert +=
+            // On.PlayerProgression.Revert += // reverts temp map data, not sure if relevant since it's not saving it and it'll be loading things from disk again
 
             // Saving
             On.PlayerProgression.SaveDeathPersistentDataOfCurrentState += PlayerProgression_SaveDeathPersistentDataOfCurrentState;
@@ -116,11 +116,11 @@ namespace CompletelyOptional
 
         #endregion HOOKS
 
-        private const bool doLog = true;
+        private static bool doLog = false;
 
-        private static void DebugLog(string text = "", [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        private static void LogMethodName([System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
         {
-            if (doLog) UnityEngine.Debug.Log(memberName + " : " + text);
+            if (doLog) UnityEngine.Debug.Log(memberName);
         }
 
         internal static void RunPreSave()
@@ -147,7 +147,7 @@ namespace CompletelyOptional
 
         internal static void LoadOIsProgression()
         {
-            DebugLog();
+            LogMethodName();
             foreach (OptionInterface oi in OptionScript.loadedInterfaces)
             {
                 if (oi.hasProgData)
@@ -160,7 +160,7 @@ namespace CompletelyOptional
 
         internal static void InitiateOIsProgression()
         {
-            DebugLog();
+            LogMethodName();
 
             RunPreSave();
             foreach (OptionInterface oi in OptionScript.loadedInterfaces)
@@ -176,13 +176,13 @@ namespace CompletelyOptional
 
         internal static void WipeOIsProgression(int saveStateNumber)
         {
-            DebugLog();
+            LogMethodName();
             RunPreSave();
             foreach (OptionInterface oi in OptionScript.loadedInterfaces)
             {
                 if (oi.hasProgData)
                 {
-                    oi.WipeProgression(saveStateNumber); // Has a chance to clear/keep misc data ?
+                    oi.WipeProgression(saveStateNumber); // Todo add a chance to clear/keep misc data ?
                 }
             }
             RunPostLoaded();
@@ -190,7 +190,7 @@ namespace CompletelyOptional
 
         internal static void LoadOIsSave(SaveState saveState, bool loadedFromMemory, bool loadedFromStarve)
         {
-            DebugLog();
+            LogMethodName();
             if (loadedFromMemory) return; // We're good ? Not too sure when this happens
             foreach (OptionInterface oi in OptionScript.loadedInterfaces)
             {
@@ -204,7 +204,7 @@ namespace CompletelyOptional
 
         internal static void SaveOIsProgression(bool saveState, bool savePers, bool saveMisc)
         {
-            DebugLog();
+            LogMethodName();
             RunPreSave();
             foreach (OptionInterface oi in OptionScript.loadedInterfaces)
             {
@@ -217,7 +217,7 @@ namespace CompletelyOptional
 
         internal static void SaveOIsPers(bool saveAsIfPlayerDied, bool saveAsIfPlayerQuit)
         {
-            DebugLog();
+            LogMethodName();
             if (!(saveAsIfPlayerDied || saveAsIfPlayerQuit))
             {
                 RunPreSave();
@@ -227,7 +227,7 @@ namespace CompletelyOptional
                 if (oi.hasProgData)
                 {
                     if (saveAsIfPlayerDied || saveAsIfPlayerQuit)
-                        oi.SaveSimulatedDeath(saveAsIfPlayerDied, saveAsIfPlayerQuit);
+                        oi.SaveDeath(saveAsIfPlayerDied, saveAsIfPlayerQuit);
                     else
                         oi.SaveProgression(false, true, false);
                 }

--- a/CompletelyOptional/ProgressData.cs
+++ b/CompletelyOptional/ProgressData.cs
@@ -1,76 +1,203 @@
 ﻿using Menu;
 using OptionalUI;
+using System;
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public class CallerMemberNameAttribute : Attribute
+    {
+    }
+}
 
 namespace CompletelyOptional
 {
     public static class ProgressData
     {
+        private static bool _patched;
         internal static void SubPatch()
         {
-            On.Menu.SlugcatSelectMenu.ctor += SlugMenuCtorPatch;
-            On.DeathPersistentSaveData.SaveToString += SaveToStringPatch;
-            On.SaveState.SessionEnded += SessionEndPatch;
-            On.SaveState.LoadGame += LoadGamePatch;
-            //On.PlayerProgression.WipeAll hmmmmm
+            if (!_patched)
+            { // Only run these hooks once
+                _patched = true;
+            } else return;
+
+            // General progression
+            // load or start fresh
+            On.PlayerProgression.LoadProgression += PlayerProgression_LoadProgression;
+            On.PlayerProgression.InitiateProgression += PlayerProgression_InitiateProgression;
+
+            // Savestate instantiation/fetch
+            On.PlayerProgression.GetOrInitiateSaveState += PlayerProgression_GetOrInitiateSaveState;
+            On.Menu.SlugcatSelectMenu.StartGame += SlugcatSelectMenu_StartGame; // lil bugfix
+
+            // Reverts and clears
+            On.PlayerProgression.WipeAll += PlayerProgression_WipeAll;
+            On.PlayerProgression.WipeSaveState += PlayerProgression_WipeSaveState;
+            // On.PlayerProgression.Revert +=
+
+            // Saving
+            On.PlayerProgression.SaveDeathPersistentDataOfCurrentState += PlayerProgression_SaveDeathPersistentDataOfCurrentState;
+            On.PlayerProgression.SaveToDisk += PlayerProgression_SaveToDisk;
+
+            // First call to progression ctor happens before we hook our hooks. OI initialization must call LoadOIsMisc();
         }
 
-        internal enum SaveAndLoad
+        #region HOOKS
+
+        // HOOKS
+        // General behavior: When saving/loading, save/load game first; when wiping, wipe mod first.
+        // this way, the game's current state is always avaiable for mods to read.
+
+        // Called trying to load a file
+        internal static void PlayerProgression_LoadProgression(On.PlayerProgression.orig_LoadProgression orig, PlayerProgression self)
         {
-            Update = 0, // Call Slot Update
-            Save = 1,
-            Load = 2
+            orig(self);
+            LoadOIsMisc();
         }
 
-        private static void SaveAndLoadOIs(SaveAndLoad saveOrLoad, bool force, bool saveAsDeath = false, bool saveAsQuit = false)
+        // Called when there's no file to load
+        internal static void PlayerProgression_InitiateProgression(On.PlayerProgression.orig_InitiateProgression orig, PlayerProgression self)
         {
+            orig(self);
+            InitiateOIsMisc();
+        }
+
+        internal static void PlayerProgression_WipeAll(On.PlayerProgression.orig_WipeAll orig, PlayerProgression self)
+        {
+            WipeOIsProgression(-1);
+            orig(self);
+        }
+
+        // Called with saveAsDeathOrQuit=true from StoryGameSession; =false from loading Red's statistics
+        internal static SaveState PlayerProgression_GetOrInitiateSaveState(On.PlayerProgression.orig_GetOrInitiateSaveState orig, PlayerProgression self, int saveStateNumber, RainWorldGame game, ProcessManager.MenuSetup setup, bool saveAsDeathOrQuit)
+        {
+            bool loadedFromStarve = self.currentSaveState == null && self.starvedSaveState != null && self.starvedSaveState.saveStateNumber == saveStateNumber;
+            bool loadedFromMemory = loadedFromStarve || (self.currentSaveState != null && self.currentSaveState.saveStateNumber == saveStateNumber);
+
+            SaveState saveState = orig(self, saveStateNumber, game, setup, saveAsDeathOrQuit);
+            
+            LoadOIsSave(saveState, loadedFromMemory, loadedFromStarve);
+            if (saveAsDeathOrQuit) SaveOIsPers(true, true);
+
+            return saveState;
+        }
+
+        internal static void SlugcatSelectMenu_StartGame(On.Menu.SlugcatSelectMenu.orig_StartGame orig, SlugcatSelectMenu self, int storyGameCharacter)
+        {
+            orig(self, storyGameCharacter);
+            // Bugfix to prevent crazy inconsistency that could happen if played restarted a save they just starved on
+            // (vanilla would call 'Wipe' and still load the starve which is clearly a bug)
+            
+            if(self.manager.menuSetup.startGameCondition == ProcessManager.MenuSetup.StoryGameInitCondition.New)
+                self.manager.rainWorld.progression.starvedSaveState = null;
+        }
+
+        internal static void PlayerProgression_WipeSaveState(On.PlayerProgression.orig_WipeSaveState orig, PlayerProgression self, int saveStateNumber)
+        {
+            WipeOIsProgression(saveStateNumber);
+            orig(self, saveStateNumber);
+        }
+
+        internal static void PlayerProgression_SaveToDisk(On.PlayerProgression.orig_SaveToDisk orig, PlayerProgression self, bool saveCurrentState, bool saveMaps, bool saveMiscProg)
+        {
+            orig(self, saveCurrentState, saveMaps, saveMiscProg);
+            SaveOIsProgression(saveCurrentState, saveCurrentState, saveMiscProg);
+        }
+
+        internal static void PlayerProgression_SaveDeathPersistentDataOfCurrentState(On.PlayerProgression.orig_SaveDeathPersistentDataOfCurrentState orig, PlayerProgression self, bool saveAsIfPlayerDied, bool saveAsIfPlayerQuit)
+        {
+            orig(self, saveAsIfPlayerDied, saveAsIfPlayerQuit);
+            SaveOIsPers(saveAsIfPlayerDied, saveAsIfPlayerQuit);
+        }
+
+        #endregion HOOKS
+
+        private const bool doLog = true;
+
+        private static void DebugLog(string text = "", [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        {
+            if (doLog) UnityEngine.Debug.Log(memberName + " : " + text);
+        }
+
+        internal static void LoadOIsMisc()
+        {
+            DebugLog();
             foreach (OptionInterface oi in OptionScript.loadedInterfaces)
             {
                 if (oi.hasProgData)
                 {
-                    if (!force && saveOrLoad == SaveAndLoad.Save)
-                    {
-                        oi.saveAsDeath = saveAsDeath;
-                        oi.saveAsQuit = saveAsQuit;
-                    }
-                    oi.ProgSaveOrLoad(saveOrLoad);
+                    oi.LoadMisc();
+                    oi.InitSave();
+                    oi.InitPers();
                 }
             }
         }
 
-        private static void SlugMenuCtorPatch(On.Menu.SlugcatSelectMenu.orig_ctor orig, SlugcatSelectMenu self, ProcessManager manager)
+        internal static void InitiateOIsMisc()
         {
-            orig.Invoke(self, manager);
-            SaveAndLoadOIs(SaveAndLoad.Update, true);
-        }
-
-        private static void SessionEndPatch(On.SaveState.orig_SessionEnded orig, SaveState self, RainWorldGame game, bool survived, bool newMalnourished)
-        {
-            orig.Invoke(self, game, survived, newMalnourished);
-            SaveAndLoadOIs(SaveAndLoad.Load, false);
-        }
-
-        private static void LoadGamePatch(On.SaveState.orig_LoadGame orig, SaveState self, string str, RainWorldGame game)
-        {
-            orig.Invoke(self, str, game);
-            if (str == string.Empty)
+            DebugLog();
+            foreach (OptionInterface oi in OptionScript.loadedInterfaces)
             {
-                // Fresh start/restart
-                foreach (OptionInterface oi in OptionScript.loadedInterfaces)
+                if (oi.hasProgData)
                 {
-                    if (oi.hasProgData) { oi.OnNewSave(false); }
+                    oi.InitMisc();
+                    oi.InitSave();
+                    oi.InitPers();
                 }
-            }
-            else
-            {
-                SaveAndLoadOIs(SaveAndLoad.Load, false);
             }
         }
 
-        private static string SaveToStringPatch(On.DeathPersistentSaveData.orig_SaveToString orig, DeathPersistentSaveData self, bool saveAsIfPlayerDied, bool saveAsIfPlayerQuit)
+
+        internal static void WipeOIsProgression(int saveStateNumber)
         {
-            string result = orig.Invoke(self, saveAsIfPlayerDied, saveAsIfPlayerQuit);
-            SaveAndLoadOIs(SaveAndLoad.Save, false, saveAsIfPlayerDied, saveAsIfPlayerQuit);
-            return result;
+            DebugLog();
+            foreach (OptionInterface oi in OptionScript.loadedInterfaces)
+            {
+                if (oi.hasProgData)
+                {
+                    oi.WipeProgression(saveStateNumber); // Has a chance to clear/keep misc data ?
+                }
+            }
+        }
+
+        internal static void LoadOIsSave(SaveState saveState, bool loadedFromMemory, bool loadedFromStarve)
+        {
+            DebugLog();
+            foreach (OptionInterface oi in OptionScript.loadedInterfaces)
+            {
+                if (oi.hasProgData)
+                {
+                    oi.LoadSave(saveState, loadedFromMemory, loadedFromStarve);
+                }
+            }
+        }
+
+        internal static void SaveOIsProgression(bool saveState, bool savePers, bool saveMisc)
+        {
+            DebugLog();
+            foreach (OptionInterface oi in OptionScript.loadedInterfaces)
+            {
+                if (oi.hasProgData)
+                {
+                    oi.SaveProgression(saveState, savePers, saveMisc);
+                }
+            }
+        }
+
+        internal static void SaveOIsPers(bool saveAsIfPlayerDied, bool saveAsIfPlayerQuit)
+        {
+            DebugLog();
+            foreach (OptionInterface oi in OptionScript.loadedInterfaces)
+            {
+                if (oi.hasProgData)
+                {
+                    if (saveAsIfPlayerDied || saveAsIfPlayerQuit)
+                        oi.SaveSimulatedDeath(saveAsIfPlayerDied, saveAsIfPlayerQuit);
+                    else
+                        oi.SaveProgression(false, true, false);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Implements most of the proposed Progression Data system, using hookpoints from the game save system to try and simulate the exact same behavior on what gets saved/load and when.

Doesn't implement continued save detection.

Uses slightly different events for the OI for saving progression, ie pre-save and post-load events, the old unified event was really awkward to use.

Not thoroughly tested, but mostly tested.